### PR TITLE
ADD check-for-updates: test for outdated packages

### DIFF
--- a/example-config/kastenwesen_config.py
+++ b/example-config/kastenwesen_config.py
@@ -4,6 +4,16 @@
 config_containers = []
 
 #########################################
+# my_linux_base                         #
+# ===================================== #
+# Linux (Ubuntu 14.04) base image       #
+#########################################
+my_linux_base = DockerContainer("my-linux-base", "./my-linux-base/", tests={})
+config_containers.append(my_linux_base)
+
+# TODO dependency on my_linux_base, without linking
+
+#########################################
 # web                                   #
 # ===================================== #
 # A web server listening on port 80     #

--- a/example-config/my-linux-base/Dockerfile
+++ b/example-config/my-linux-base/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+# update packages
+RUN apt-get update && apt-get -y dist-upgrade && apt-get -y upgrade
+# install dependencies of update check helper
+RUN apt-get -y install python3 python3-apt
+# basic tools like editor etc.
+RUN apt-get -y install curl wget nano
+RUN apt-get clean
+
+# fake command that never exits
+# TODO can be removed as soon as not-running 'template containers' are supported
+CMD sleep 999999999999999d

--- a/example-config/portforwarder-to-test2/Dockerfile
+++ b/example-config/portforwarder-to-test2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM my-linux-base
 
 RUN apt-get update
 RUN apt-get install -y socat

--- a/example-config/test1/Dockerfile
+++ b/example-config/test1/Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:14.04
+FROM my-linux-base
 
 RUN apt-get update
 RUN apt-get install -y netcat
 RUN apt-get clean
-# remove apt lists
-RUN rm -rf /var/lib/apt/lists/*
 
 
 

--- a/example-config/test2/Dockerfile
+++ b/example-config/test2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM my-linux-base
 
 RUN apt-get update
 RUN apt-get install -y socat

--- a/example-config/webserver/Dockerfile
+++ b/example-config/webserver/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:14.04
+FROM my-linux-base
 
 RUN apt-get update
 RUN apt-get install -y webfs
+RUN apt-get clean
 RUN mkdir /var/www
 
 

--- a/helper/check_for_updates.py
+++ b/helper/check_for_updates.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import apt
+import sys
+cache = apt.Cache()
+try:
+    cache.update()
+except apt.cache.LockFailedException:
+    sys.stderr.write("Failed to get lock for apt-get update. Are you root?\n")
+    sys.exit(1)
+# this only simulates a dist-upgrade:
+cache.upgrade(dist_upgrade=True)
+changes = cache.get_changes()
+if changes:
+    print(" ".join([change.name for change in changes]))
+sys.exit(0)


### PR DESCRIPTION
`kastenwesen check-for-updates` runs a python script roughly equivalent to `apt-get update && apt-get --simulate upgrade` in each container. The return code can be used for a warning cron job.
