### PR TITLE
allow auto-upgrade to be disabled and forced

### DIFF
--- a/example-config/kastenwesen_config.py
+++ b/example-config/kastenwesen_config.py
@@ -3,6 +3,8 @@
 
 config_containers = []
 
+disable_auto_upgrade = True
+
 travis = False
 if os.environ.get("TRAVIS"):
     print("\nHey Travis, nice to see you. I will progress slowly for you, so my tests won't fail.\n")


### PR DESCRIPTION
This will allow to just call check-for-updates with --auto-upgrade and disable it by setting disable_auto_upgrade to True in kastenwesen_config.py.
