### PR TITLE
Make DockerContainer a child of AbstractTask and not tasks a child of AbstractContainer

### DIFF
--- a/kastenwesen.py
+++ b/kastenwesen.py
@@ -52,6 +52,7 @@ If the containers argument is not given, the command refers to all containers in
 """
 
 from __future__ import print_function
+import abc
 import docker
 import sys
 import logging


### PR DESCRIPTION
I think this makes more sense.

And use `abc` to make classes abstract.