### PR TITLE
Don't run check-for-updates with interactive TTY

### DIFF
--- a/kastenwesen.py
+++ b/kastenwesen.py
@@ -646,7 +646,7 @@ class DockerContainer(AbstractContainer):
                     kastenwesen_path=kastenwesen_path,
                 )
             )
-            cmd = "docker exec -it --user=root {container}" \
+            cmd = "docker exec --user=root {container}" \
                 " /usr/local/helper/python-wrapper.sh" \
                 " /usr/local/helper/check_for_updates.py".format(
                     container=self.running_container_name(),


### PR DESCRIPTION
Hopefully fixes #52:

`kastenwesen check-for-updates` crashed during cron jobs with message:

> the input device is not a TTY

because of the `-it`.